### PR TITLE
Return non-zero exit code for non graceful shutdown

### DIFF
--- a/lib/vector-buffers/src/variants/disk_v2/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/reader.rs
@@ -977,7 +977,7 @@ where
             if self.ledger.is_writer_done() {
                 let total_buffer_size = self.ledger.get_total_buffer_size();
                 if total_buffer_size == 0 {
-                    debug!("writer is done and total buffer size is 0");
+                    debug!("buffer writer is done and buffer is empty")
                     return Ok(None);
                 }
             }
@@ -1075,7 +1075,7 @@ where
                     continue;
                 }
 
-                debug!("reader is on writer's current data file: waiting for writer to wake the reader");
+                debug!("waiting for buffer writer to wake the reader");
                 self.ledger.wait_for_writer().await;
             } else {
                 debug!(

--- a/lib/vector-buffers/src/variants/disk_v2/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/reader.rs
@@ -977,6 +977,7 @@ where
             if self.ledger.is_writer_done() {
                 let total_buffer_size = self.ledger.get_total_buffer_size();
                 if total_buffer_size == 0 {
+                    debug!("writer is done and total buffer size is 0");
                     return Ok(None);
                 }
             }
@@ -1074,6 +1075,7 @@ where
                     continue;
                 }
 
+                debug!("reader is on writer's current data file: waiting for writer to wake the reader");
                 self.ledger.wait_for_writer().await;
             } else {
                 debug!(

--- a/lib/vector-buffers/src/variants/disk_v2/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/reader.rs
@@ -977,7 +977,7 @@ where
             if self.ledger.is_writer_done() {
                 let total_buffer_size = self.ledger.get_total_buffer_size();
                 if total_buffer_size == 0 {
-                    debug!("buffer writer is done and buffer is empty")
+                    debug!("buffer writer is done and buffer is empty");
                     return Ok(None);
                 }
             }

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -206,7 +206,7 @@ impl RunningTopology {
         // Panic to ensure that Vector returns a non-zero exit code when it's unable to gracefully shutdown
         futures::future::join(source_shutdown_complete, shutdown_complete_future)
             .map(|futures| match futures.1.0 {
-                Result::Err(s) => panic!(format!("failed to gracefully shutdown in time, panic to force non-zero exit code: {s}")),
+                Result::Err(s) => panic!("failed to gracefully shutdown in time, panic to force non-zero exit code. remaining components: {}", &s),
                 Result::Ok(_) => (),
             })
     }

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -203,9 +203,10 @@ impl RunningTopology {
         // Now kick off the shutdown process by shutting down the sources.
         let source_shutdown_complete = self.shutdown_coordinator.shutdown_all(deadline).map(|_| Result::<(), ()>::Ok(()));
 
+        // Panic to ensure that Vector returns a non-zero exit code when it's unable to gracefully shutdown
         futures::future::join(source_shutdown_complete, shutdown_complete_future)
-            .map(|xy| match xy.1.0 {
-                Result::Err(_) => panic!("alexj's panic: failed to gracefully shutdown in time"),
+            .map(|futures| match futures.1.0 {
+                Result::Err(_) => panic!("failed to gracefully shutdown in time, panic to force non-zero exit code"),
                 Result::Ok(_) => (),
             })
     }

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -152,7 +152,7 @@ impl RunningTopology {
                     components = ?remaining_components,
                     "Failed to gracefully shut down in time. Killing components."
                 );
-                Result::Err(())
+                Result::Err(remaining_components)
             }) as future::BoxFuture<'static, Result<(), ()>>
         } else {
             Box::pin(future::pending()) as future::BoxFuture<'static, Result<(), ()>>
@@ -195,18 +195,18 @@ impl RunningTopology {
 
         // Aggregate future that ends once anything detects that all tasks have shutdown.
         let shutdown_complete_future = future::select_all(vec![
-            Box::pin(timeout) as future::BoxFuture<'static, Result<(), ()>>,
-            Box::pin(reporter.map(|()| Result::<(), ()>::Ok(()))) as future::BoxFuture<'static, Result<(), ()>>,
-            Box::pin(success) as future::BoxFuture<'static, Result<(), ()>>,
+            Box::pin(timeout) as future::BoxFuture<'static, Result<(), String>>,
+            Box::pin(reporter.map(|()| Result::<(), String>::Ok(()))) as future::BoxFuture<'static, Result<(), String>>,
+            Box::pin(success) as future::BoxFuture<'static, Result<(), String>>,
         ]);
 
         // Now kick off the shutdown process by shutting down the sources.
-        let source_shutdown_complete = self.shutdown_coordinator.shutdown_all(deadline).map(|_| Result::<(), ()>::Ok(()));
+        let source_shutdown_complete = self.shutdown_coordinator.shutdown_all(deadline).map(|_| Result::<(), String>::Ok(()));
 
         // Panic to ensure that Vector returns a non-zero exit code when it's unable to gracefully shutdown
         futures::future::join(source_shutdown_complete, shutdown_complete_future)
             .map(|futures| match futures.1.0 {
-                Result::Err(_) => panic!("failed to gracefully shutdown in time, panic to force non-zero exit code"),
+                Result::Err(s) => panic!(format!("failed to gracefully shutdown in time, panic to force non-zero exit code: {s}")),
                 Result::Ok(_) => (),
             })
     }

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -152,9 +152,10 @@ impl RunningTopology {
                     components = ?remaining_components,
                     "Failed to gracefully shut down in time. Killing components."
                 );
-            }) as future::BoxFuture<'static, ()>
+                Result::Err(())
+            }) as future::BoxFuture<'static, Result<(), ()>>
         } else {
-            Box::pin(future::pending()) as future::BoxFuture<'static, ()>
+            Box::pin(future::pending()) as future::BoxFuture<'static, Result<(), ()>>
         };
 
         // Reports in intervals which components are still running.
@@ -190,19 +191,23 @@ impl RunningTopology {
         };
 
         // Finishes once all tasks have shutdown.
-        let success = futures::future::join_all(wait_handles).map(|_| ());
+        let success = futures::future::join_all(wait_handles).map(|_| Result::Ok(()));
 
         // Aggregate future that ends once anything detects that all tasks have shutdown.
         let shutdown_complete_future = future::select_all(vec![
-            Box::pin(timeout) as future::BoxFuture<'static, ()>,
-            Box::pin(reporter) as future::BoxFuture<'static, ()>,
-            Box::pin(success) as future::BoxFuture<'static, ()>,
+            Box::pin(timeout) as future::BoxFuture<'static, Result<(), ()>>,
+            Box::pin(reporter) as future::BoxFuture<'static, Result<(), ()>>,
+            Box::pin(success) as future::BoxFuture<'static, Result<(), ()>>,
         ]);
 
         // Now kick off the shutdown process by shutting down the sources.
-        let source_shutdown_complete = self.shutdown_coordinator.shutdown_all(deadline);
+        let source_shutdown_complete = self.shutdown_coordinator.shutdown_all(deadline).map(|_| Result::Ok(()));
 
-        futures::future::join(source_shutdown_complete, shutdown_complete_future).map(|_| ())
+        futures::future::join(source_shutdown_complete, shutdown_complete_future)
+            .map(|xy| match xy.1.0 {
+                Result::Err(_) => panic!("alexj's panic: failed to gracefully shutdown in time"),
+                Result::Ok(_) => (),
+            })
     }
 
     /// Attempts to load a new configuration and update this running topology.

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -196,7 +196,7 @@ impl RunningTopology {
         // Aggregate future that ends once anything detects that all tasks have shutdown.
         let shutdown_complete_future = future::select_all(vec![
             Box::pin(timeout) as future::BoxFuture<'static, Result<(), ()>>,
-            Box::pin(reporter) as future::BoxFuture<'static, Result<(), ()>>,
+            Box::pin(reporter) as future::BoxFuture<'static, ()>,
             Box::pin(success) as future::BoxFuture<'static, Result<(), ()>>,
         ]);
 

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -153,9 +153,9 @@ impl RunningTopology {
                     "Failed to gracefully shut down in time. Killing components."
                 );
                 Result::Err(remaining_components)
-            }) as future::BoxFuture<'static, Result<(), ()>>
+            }) as future::BoxFuture<'static, Result<(), String>>
         } else {
-            Box::pin(future::pending()) as future::BoxFuture<'static, Result<(), ()>>
+            Box::pin(future::pending()) as future::BoxFuture<'static, Result<(), String>>
         };
 
         // Reports in intervals which components are still running.

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -188,6 +188,7 @@ impl RunningTopology {
                     "Shutting down... Waiting on running components."
                 );
             }
+            Result::Ok(())
         };
 
         // Finishes once all tasks have shutdown.

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -188,7 +188,6 @@ impl RunningTopology {
                     "Shutting down... Waiting on running components."
                 );
             }
-            Result::Ok(())
         };
 
         // Finishes once all tasks have shutdown.
@@ -202,7 +201,7 @@ impl RunningTopology {
         ]);
 
         // Now kick off the shutdown process by shutting down the sources.
-        let source_shutdown_complete = self.shutdown_coordinator.shutdown_all(deadline).map(|_| Result::Ok(()));
+        let source_shutdown_complete = self.shutdown_coordinator.shutdown_all(deadline).map(|_| Result::<(), ()>::Ok(()));
 
         futures::future::join(source_shutdown_complete, shutdown_complete_future)
             .map(|xy| match xy.1.0 {

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -196,7 +196,7 @@ impl RunningTopology {
         // Aggregate future that ends once anything detects that all tasks have shutdown.
         let shutdown_complete_future = future::select_all(vec![
             Box::pin(timeout) as future::BoxFuture<'static, Result<(), ()>>,
-            Box::pin(reporter) as future::BoxFuture<'static, ()>,
+            Box::pin(reporter.map(|()| Result::<(), ()>::Ok(()))) as future::BoxFuture<'static, Result<(), ()>>,
             Box::pin(success) as future::BoxFuture<'static, Result<(), ()>>,
         ]);
 


### PR DESCRIPTION
When testing in staging with a broken pubsub sink (& healthcheck disabled so that vector will start), the vector process returns a exit code of 0, even though it fails to shut down the sink component within the graceful shutdown time limit.

This change will update the behavior so that Vector shutsdown with a non-zero exit code (which we can use later on to determine whether vector was gracefully shutdown or not, so we can determine whether or not to run buffer recovery)

test cases: see [PR comment below](https://github.com/discord/vector/pull/8#issuecomment-2590933157)