### PR TITLE
Reify UDS rebind logic

### DIFF
--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -51,6 +51,7 @@ use crate::{
     sources::{
         util::{
             net::{try_bind_tcp_listener, MAX_IN_FLIGHT_EVENTS_TARGET},
+            unix::remove_stale_socket,
             AfterReadExt,
         },
         Source,
@@ -598,19 +599,7 @@ pub fn build_framestream_unix_source(
 ) -> crate::Result<Source> {
     let path = frame_handler.socket_path();
 
-    //check if the path already exists (and try to delete it)
-    match fs::metadata(&path) {
-        Ok(_) => {
-            //exists, so try to delete it
-            info!(message = "Deleting file.", ?path);
-            fs::remove_file(&path)?;
-        }
-        Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {} //doesn't exist, do nothing
-        Err(e) => {
-            error!("Unable to get socket information; error = {:?}.", e);
-            return Err(Box::new(e));
-        }
-    };
+    remove_stale_socket(&path);
 
     let listener = UnixListener::bind(&path)?;
 

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -1,9 +1,39 @@
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::{fs, fs::remove_file, path::Path};
 
 use crate::internal_events::UnixSocketFileDeleteError;
 
 pub const UNNAMED_SOCKET_HOST: &str = "(unnamed)";
+
+/// Remove a stale Unix domain socket file left over from a previous run (e.g.
+/// after a crash or SIGKILL). If the path exists but is not a socket, we leave
+/// it alone and log an error — we should never silently delete a regular file
+/// that someone may have placed at this path by mistake.
+pub fn remove_stale_socket(path: &Path) {
+    match fs::symlink_metadata(path) {
+        Ok(meta) => {
+            if !meta.file_type().is_socket() {
+                error!(
+                    message = "Socket path already exists and is not a UNIX socket. Remove the file or choose a different path.",
+                    path = ?path,
+                );
+                return;
+            }
+            match remove_file(path) {
+                Ok(()) => {
+                    info!(message = "Removed stale UNIX socket file.", path = ?path);
+                }
+                Err(error) => {
+                    emit!(UnixSocketFileDeleteError { path, error });
+                }
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            warn!(message = "Unable to check socket path.", path = ?path, %error);
+        }
+    }
+}
 
 pub fn change_socket_permissions(path: &Path, perms: Option<u32>) -> crate::Result<()> {
     if let Some(mode) = perms {
@@ -18,4 +48,45 @@ pub fn change_socket_permissions(path: &Path, perms: Option<u32>) -> crate::Resu
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::net::UnixListener;
+    use tempfile::tempdir;
+
+    #[test]
+    fn remove_stale_socket_removes_existing_socket() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.sock");
+
+        drop(UnixListener::bind(&path).unwrap());
+        assert!(path.exists());
+
+        remove_stale_socket(&path);
+        assert!(!path.exists(), "stale socket file should have been removed");
+    }
+
+    #[test]
+    fn remove_stale_socket_does_not_delete_regular_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("not_a_socket.txt");
+
+        fs::write(&path, "important data").unwrap();
+        assert!(path.exists());
+
+        remove_stale_socket(&path);
+        assert!(path.exists(), "regular file must not be deleted");
+        assert_eq!(fs::read_to_string(&path).unwrap(), "important data");
+    }
+
+    #[test]
+    fn remove_stale_socket_noop_when_path_missing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonexistent.sock");
+
+        remove_stale_socket(&path);
+        assert!(!path.exists());
+    }
 }

--- a/src/sources/util/unix_datagram.rs
+++ b/src/sources/util/unix_datagram.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     shutdown::ShutdownSignal,
     sources::util::change_socket_permissions,
-    sources::util::unix::UNNAMED_SOCKET_HOST,
+    sources::util::unix::{remove_stale_socket, UNNAMED_SOCKET_HOST},
     sources::Source,
     SourceSender,
 };
@@ -37,6 +37,8 @@ pub fn build_unix_datagram_source(
     out: SourceSender,
 ) -> crate::Result<Source> {
     Ok(Box::pin(async move {
+        remove_stale_socket(&listen_path);
+
         let socket = UnixDatagram::bind(&listen_path).expect("Failed to bind to datagram socket");
         info!(message = "Listening.", path = ?listen_path, r#type = "unix_datagram");
 

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     shutdown::ShutdownSignal,
     sources::util::change_socket_permissions,
-    sources::util::unix::UNNAMED_SOCKET_HOST,
+    sources::util::unix::{remove_stale_socket, UNNAMED_SOCKET_HOST},
     sources::Source,
     SourceSender,
 };
@@ -43,6 +43,8 @@ pub fn build_unix_stream_source(
     out: SourceSender,
 ) -> crate::Result<Source> {
     Ok(Box::pin(async move {
+        remove_stale_socket(&listen_path);
+
         let listener = UnixListener::bind(&listen_path).unwrap_or_else(|e| {
             panic!(
                 "Failed to bind to listener socket at path: {}. Err: {}",


### PR DESCRIPTION
Vector doesn't properly clean up stale UDS even in upstream, despite having support in the repo since 2020.  That can create situations where vector can fail to startup in a kubernetes environment, since it can't re-bind to a location which is already occupied.

This is a solvable problem.  The Datadog agent has a [fairly idiomatic](https://github.com/DataDog/datadog-agent/blob/main/comp/dogstatsd/listeners/uds_common.go#L112-L129) way of handling it.  I took a stab at copying over that logic here.

1. Check to see if the file already exists
2. If so, check if it's a unix domain socket
3. If so, then try to delete it because it's probably ours

I added a test too.

This is a driveby PR; I'm not really a consumer of this repo or anything, but I saw a callout on this behavior, investigated it, and sure enough it had the typical defect.